### PR TITLE
Add transform exponentiation operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
     require("babel-plugin-syntax-object-rest-spread"),
     require("babel-plugin-transform-object-rest-spread"),
     require("babel-plugin-transform-es3-property-literals"),
+    require("babel-plugin-transform-exponentiation-operator"),
     require("babel-plugin-transform-flow-strip-types"),
     require("babel-plugin-transform-regenerator")
   ]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-plugin-transform-es2015-typeof-symbol": "^6.8.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
     "babel-plugin-transform-es3-property-literals": "^6.8.0",
+    "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-plugin-transform-regenerator": "^6.16.1",


### PR DESCRIPTION
The default meteor preset is annoyingly missing the [ES2016 syntax].
The singla transformation included is the [exponentiation operator],
allowing syntax like:

```js
1024 ** 3 === Math.pow(1024, 3);
```

[ES2016 syntax]: https://babeljs.io/docs/plugins/preset-es2016/
[exponentiation operator]: https://babeljs.io/docs/plugins/transform-exponentiation-operator/